### PR TITLE
Fixed adding url parameters

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -225,7 +225,8 @@ class LinkedIn
      */
     public function fetch($endpoint, array $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
     {
-        $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . '?oauth2_access_token=' . $this->getAccessToken();
+        $concat = (stristr($endpoint,'?') ? '&' : '?');
+        $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . $concat . 'oauth2_access_token=' . $this->getAccessToken();
         $headers[] = 'x-li-format: json';
 
         return $this->_makeRequest($endpoint, $payload, $method, $headers, $curl_options);


### PR DESCRIPTION
Added logic to support linkedin requests with parameters e.g. https://api.linkedin.com/v1/people/~/connections?start=0&count=50&oauth2_access_token=AQVk0n84W4yjV...