### PR TITLE
removed array typehinting for $payloayd

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -182,7 +182,7 @@ class LinkedIn
      * @param array $payload
      * @return array
      */
-    public function post($endpoint, array $payload = array())
+    public function post($endpoint, $payload = array())
     {
         return $this->fetch($endpoint, $payload, self::HTTP_METHOD_POST);
     }
@@ -206,7 +206,7 @@ class LinkedIn
      * @param array $payload
      * @return array
      */
-    public function put($endpoint, array $payload = array())
+    public function put($endpoint, $payload = array())
     {
         return $this->fetch($endpoint, $payload, self::HTTP_METHOD_PUT);
     }
@@ -223,7 +223,7 @@ class LinkedIn
      * @param array $curl_options
      * @return array
      */
-    public function fetch($endpoint, array $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
+    public function fetch($endpoint, $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
     {
         $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . '?oauth2_access_token=' . $this->getAccessToken();
         $headers[] = 'x-li-format: json';
@@ -252,7 +252,7 @@ class LinkedIn
      * @throws \RuntimeException
      * @return array
      */
-    protected function _makeRequest($url, array $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
+    protected function _makeRequest($url, $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
     {
         $ch = $this->_getCurlHandle();
 


### PR DESCRIPTION
you must be able to send not only arrays, but also simple strings as JSON
$linkedin->put("/posts/xxx/category/code", "job");

last example in https://developer.linkedin.com/documents/api-requests-json