### PR TITLE
Added Authorization: Bearer header to the request

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -240,6 +240,7 @@ class LinkedIn
         $concat = (stristr($endpoint,'?') ? '&' : '?');
         $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . $concat . 'oauth2_access_token=' . $this->getAccessToken();
         $headers[] = 'x-li-format: json';
+        $headers[] = 'Authorization: Bearer ' . $this->getAccessToken();
 
         return $this->_makeRequest($endpoint, $payload, $method, $headers, $curl_options);
     }


### PR DESCRIPTION
I have faced a problem where LinkedIn would return `Unknown authentication scheme` because the token was only included in the HTTP parameters. However, the official documentation states that to successfully sign requests, we have to include an Authorization header:

> Once you've obtained an Access Token, you can start making authenticated API requests on behalf of the user. This is accomplished by including an "Authorization" header in your HTTP call to LinkedIn's API.

So I edited the class to include the header in the fetch method.