### PR TITLE
Remove the oauth2_access_token query parameter.

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -238,7 +238,7 @@ class LinkedIn
     public function fetch($endpoint, array $payload = array(), $method = 'GET', array $headers = array(), array $curl_options = array())
     {
         $concat = (stristr($endpoint,'?') ? '&' : '?');
-        $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . $concat . 'oauth2_access_token=' . $this->getAccessToken();
+        $endpoint = self::API_BASE . '/' . trim($endpoint, '/\\') . $concat;
         $headers[] = 'x-li-format: json';
         $headers[] = 'Authorization: Bearer ' . $this->getAccessToken();
 


### PR DESCRIPTION
According to LinkedIn's API documentation the proper way to authenticate api requests is to use the Authorization header. Once that was added having the oauth2_access_token parameter caused the API to respond with a" Multiple authentication schemes" error.