### PR TITLE
Consider 'callback_url' optional at __construct()

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -30,7 +30,7 @@ class LinkedIn
     const HTTP_METHOD_DELETE = 'DELETE';
 
     /**
-     * @param array $config (api_key, api_secret, callback_url)
+     * @param array $config (api_key, api_secret, callback_url [optional])
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
@@ -44,7 +44,7 @@ class LinkedIn
             throw new \InvalidArgumentException('Invalid api secret - make sure api_secret is defined in the config array');
         }
 
-        if (!isset($config['callback_url']) || empty($config['callback_url'])) {
+        if (isset($config['callback_url']) && empty($config['callback_url'])) {
             throw new \InvalidArgumentException('Invalid callback url - make sure callback_url is defined in the config array');
         }
 
@@ -56,14 +56,38 @@ class LinkedIn
     }
 
     /**
+     * Set the callback url after the instance is already created.
+     *
+     * @param string $callback_url
+     */
+    public function setCallbackUrl($callback_url = null)
+    {
+        if (empty($callback_url)) {
+            throw new \InvalidArgumentException('Invalid callback url - it should be set to login the user or get a new token');
+        }
+
+        $this->_config['callback_url'] = (string) $callback_url;
+    }
+
+    /**
      * Get the login url, pass scope to request specific permissions
      *
      * @param array $scope - an array of requested permissions (can use scope constants defined in this class)
      * @param string $state - a unique identifier for this user, if none is passed, one is generated via uniqid
+     * @param string $callback_url - if empty, the callback url from config array set at constructor or using setCallbackUrl() must be set
+     * @throws \InvalidArgumentException
      * @return string $url
      */
-    public function getLoginUrl(array $scope = array(), $state = null)
+    public function getLoginUrl(array $scope = array(), $state = null, $callback_url = null)
     {
+        if (empty($callback_url)) {
+            if (!isset($this->_config['callback_url']) || empty($this->_config['callback_url'])) {
+                throw new \InvalidArgumentException('Invalid callback url. Inform the "callback_url" parameter');
+            }
+
+            $callback_url = $this->_config['callback_url'];
+        }
+
         if (!empty($scope)) {
             $scope = implode('%20', $scope);
         }
@@ -73,7 +97,7 @@ class LinkedIn
         }
         $this->setState($state);
 
-        $url = self::OAUTH_BASE . "/authorization?response_type=code&client_id={$this->_config['api_key']}&scope={$scope}&state={$state}&redirect_uri=" . urlencode($this->_config['callback_url']);
+        $url = self::OAUTH_BASE . "/authorization?response_type=code&client_id={$this->_config['api_key']}&scope={$scope}&state={$state}&redirect_uri=" . urlencode($callback_url);
 
         return $url;
     }
@@ -82,18 +106,27 @@ class LinkedIn
      * Exchange the authorization code for an access token
      *
      * @param string $authorization_code
+     * @param string $callback_url - if empty, the callback url from config array set at constructor or using setCallbackUrl() must be set
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      * @return string $access_token
      */
-    public function getAccessToken($authorization_code = null)
+    public function getAccessToken($authorization_code = null, $callback_url = null)
     {
         if (!empty($this->_access_token)) {
             return $this->_access_token;
         }
 
+        if (empty($callback_url)) {
+            if (!isset($this->_config['callback_url']) || empty($this->_config['callback_url'])) {
+                throw new \InvalidArgumentException('Invalid callback url. Inform the "callback_url" parameter');
+            }
+
+            $callback_url = $this->_config['callback_url'];
+        }
+
         if (empty($authorization_code)) {
-            throw new \InvalidArgumentException('Invalid authorization code. Pass in the "code" parameter from your callback url');
+            throw new \InvalidArgumentException('Invalid authorization code. Pass the "code" parameter from your callback url');
         }
 
         $params = array(
@@ -101,7 +134,7 @@ class LinkedIn
             'code' => $authorization_code,
             'client_id' => $this->_config['api_key'],
             'client_secret' => $this->_config['api_secret'],
-            'redirect_uri' => $this->_config['callback_url']
+            'redirect_uri' => $callback_url
         );
 
         /** Temp bug fix as per https://developer.linkedin.com/comment/28938#comment-28938 **/

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you already have a valid access token stored, you may omit the setting ```cal
 
 #### 1. Use ```setCallbackUrl()``` for set the callback url after the instantiation.
 ```php
-$li->setCallbackUrl('http://example.com');
+$li->setCallbackUrl('https://yourdomain.com/redirecthere');
 ```
 
 #### 2. Use as parameter on methods while in authentication flow.
@@ -70,8 +70,8 @@ $li->setCallbackUrl('http://example.com');
 > The passed parameter must be the same for both methods below!
 
 ```php
-$my_callback_url = 'http://example.com';
+$callback_url = 'https://yourdomain.com/redirecthere';
 
-$url = $li->getLoginUrl($my_scopes, $my_callback_url); // $my_scopes is the array of SCOPES
-$token = $li->getAccessToken($_REQUEST['code'], $my_callback_url);
+$url = $li->getLoginUrl($scopes, $callback_url); // $scopes is the array of SCOPES
+$token = $li->getAccessToken($_REQUEST['code'], $callback_url);
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Instantiate our class
 ```php
 $li = new LinkedIn(
   array(
-    'api_key' => 'yourapikey', 
-    'api_secret' => 'yourapisecret', 
-    'callback_url' => 'https://yourdomain.com/redirecthere'
+    'api_key' => 'yourapikey',
+    'api_secret' => 'yourapisecret',
+    'callback_url' => 'https://yourdomain.com/redirecthere' // OPTIONAL
   )
 );
 ```
@@ -22,14 +22,14 @@ Get the login URL - this accepts an array of SCOPES
 ```php
 $url = $li->getLoginUrl(
   array(
-    LinkedIn::SCOPE_BASIC_PROFILE, 
-    LinkedIn::SCOPE_EMAIL_ADDRESS, 
+    LinkedIn::SCOPE_BASIC_PROFILE,
+    LinkedIn::SCOPE_EMAIL_ADDRESS,
     LinkedIn::SCOPE_NETWORK
   )
 );
 ```
 
-LinkedIn will redirect to 'callback_url' with an access token as the 'code' parameter. 
+LinkedIn will redirect to 'callback_url' with an access token as the 'code' parameter.
 You might want to store the token in your session so the user doesn't have to log in again
 ```php
 $token = $li->getAccessToken($_REQUEST['code']);
@@ -41,16 +41,37 @@ Make a request to the API
 $info = $li->get('/people/~:(first-name,last-name,positions)');
 ```
 
-Overwrite curl options :
+## Overwrite curl options
 ```php
 $li = new LinkedIn(
   array(
-    'api_key' => 'yourapikey', 
-    'api_secret' => 'yourapisecret', 
+    'api_key' => 'yourapikey',
+    'api_secret' => 'yourapisecret',
     'callback_url' => 'https://yourdomain.com/redirecthere',
     'curl_options' => array(
         CURLOPT_PROXY => '127.0.0.1:80',
     ),
   )
 );
+```
+
+## [Advanced] Make the callback url optional
+> **Note:** You must have the `callback_url` set for use authentication methods. Be careful :)
+
+If you already have a valid access token stored, you may omit the setting ```callback_url``` from your config array on instantiation. Depending of the logic you have used on your code it might be useful. You may use two ways:
+
+#### 1. Use ```setCallbackUrl()``` for set the callback url after the instantiation.
+```php
+$li->setCallbackUrl('http://example.com');
+```
+
+#### 2. Use as parameter on methods while in authentication flow.
+
+> The passed parameter must be the same for both methods below!
+
+```php
+$my_callback_url = 'http://example.com';
+
+$url = $li->getLoginUrl($my_scopes, $my_callback_url); // $my_scopes is the array of SCOPES
+$token = $li->getAccessToken($_REQUEST['code'], $my_callback_url);
 ```

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,10 @@
             "name": "Ashwin Surajbali",
             "email": "ashwin@redinkdesign.net",
             "homepage": "http://www.redinkdesign.co"
+        },
+        {
+            "name": "Alexandre Azevedo",
+            "homepage": "http://www.alexandreazevedo.me"
         }
     ],
     "require": {


### PR DESCRIPTION
Hi @ashwinks,

I've added support to the `callback_url` parameter at config array to be optional.

When using the library, I've extended it on my projects for reuse with multiple providers and what I would like to avoid is to set the `callback_url` on every instantiation. It's only required to authentication flow, as the same way in other OAuth2 APIs.

Could you merge it into your repository? The changes you not affect who is using the library. It's a stable update.

Thanks,
Alex