### PR TITLE
Linkedin API v2 update

### DIFF
--- a/LinkedIn/LinkedIn.php
+++ b/LinkedIn/LinkedIn.php
@@ -11,10 +11,10 @@ class LinkedIn
     private $_debug_info = null;
     private $_curl_handle = null;
 
-    const API_BASE = 'https://api.linkedin.com/v1';
-    const OAUTH_BASE = 'https://www.linkedin.com/uas/oauth2';
+    const API_BASE = 'https://api.linkedin.com/v2';
+    const OAUTH_BASE = 'https://www.linkedin.com/oauth/v2';
 
-    const SCOPE_BASIC_PROFILE = 'r_basicprofile'; // Name, photo, headline, and current positions
+    const SCOPE_BASIC_PROFILE = 'r_liteprofile'; // Name, photo, headline, and current positions
     const SCOPE_FULL_PROFILE = 'r_fullprofile'; // Full profile including experience, education, skills, and recommendations
     const SCOPE_EMAIL_ADDRESS = 'r_emailaddress'; // The primary email address you use for your LinkedIn account
     const SCOPE_NETWORK = 'r_network'; // Your 1st and 2nd degree connections


### PR DESCRIPTION
Linkedin API v1 is no longer supported since May the 1st, 2019.
- https://engineering.linkedin.com/blog/2018/12/developer-program-updates
- https://docs.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/migration-faq?context=linkedin/consumer/context